### PR TITLE
Feature geometry api

### DIFF
--- a/GeoJSON4EntityFramework/Base/GeometryType.vb
+++ b/GeoJSON4EntityFramework/Base/GeometryType.vb
@@ -1,0 +1,12 @@
+﻿''' <summary>
+''' Defines the valid geometry types
+''' </summary>
+Public Class GeometryType
+    Public Const Point As String = "Point"
+    Public Const MultiPoint As String = "MultiPoint"
+    Public Const LineString As String = "LineString"
+    Public Const MultiLineString As String = "MultiLineString"
+    Public Const Polygon As String = "Polygon"
+    Public Const MultiPolygon As String = "MultiPolygon"
+    Public Const GeometryCollection As String = "GeometryCollection"
+End Class

--- a/GeoJSON4EntityFramework/Base/IGeometry.vb
+++ b/GeoJSON4EntityFramework/Base/IGeometry.vb
@@ -23,4 +23,13 @@ Public Interface IGeoJsonGeometry
     ''' <returns></returns>
     Function Transform(ByVal xform As CoordinateTransform) As IGeoJsonGeometry
 
+    ''' <summary>
+    ''' Returns the bounding box of this geometry instance. This is null if the geometry was created from a call to
+    ''' FromDbGeometry or FromDbGeography with withBoundingBox = false
+    ''' 
+    ''' If set, the bounding box follows the format: [minY, minX, maxY, maxX]
+    ''' </summary>
+    ''' <returns></returns>
+    ReadOnly Property BoundingBox As Double()
+
 End Interface

--- a/GeoJSON4EntityFramework/Base/IGeometry.vb
+++ b/GeoJSON4EntityFramework/Base/IGeometry.vb
@@ -1,9 +1,26 @@
-﻿Public Interface IGeoJsonGeometry
+﻿''' <summary>
+''' A function that transforms the given coordinate
+''' </summary>
+''' <param name="x"></param>
+''' <param name="y"></param>
+''' <param name="tx"></param>
+''' <param name="ty"></param>
+''' <returns></returns>
+Public Delegate Function CoordinateTransform(ByVal x As Double, ByVal y As Double, ByRef tx As Double, ByRef ty As Double) As Boolean
+
+Public Interface IGeoJsonGeometry
 
     ''' <summary>
     ''' Gets the type of the geometry. This can be any constant under <see cref="GeometryType"/>
     ''' </summary>
     ''' <returns>The type of the geometry</returns>
     ReadOnly Property TypeName As String
+
+    ''' <summary>
+    ''' Returns a transformed instance of the given geometry using the suppled coordinate transform function
+    ''' </summary>
+    ''' <param name="xform">The coordinate transform function</param>
+    ''' <returns></returns>
+    Function Transform(ByVal xform As CoordinateTransform) As IGeoJsonGeometry
 
 End Interface

--- a/GeoJSON4EntityFramework/Base/IGeometry.vb
+++ b/GeoJSON4EntityFramework/Base/IGeometry.vb
@@ -1,4 +1,9 @@
-﻿
-Public Interface IGeoJsonGeometry
+﻿Public Interface IGeoJsonGeometry
+
+    ''' <summary>
+    ''' Gets the type of the geometry. This can be any constant under <see cref="GeometryType"/>
+    ''' </summary>
+    ''' <returns>The type of the geometry</returns>
+    ReadOnly Property TypeName As String
 
 End Interface

--- a/GeoJSON4EntityFramework/Base/IGeometry.vb
+++ b/GeoJSON4EntityFramework/Base/IGeometry.vb
@@ -17,7 +17,8 @@ Public Interface IGeoJsonGeometry
     ReadOnly Property TypeName As String
 
     ''' <summary>
-    ''' Returns a transformed instance of the given geometry using the suppled coordinate transform function
+    ''' Returns a transformed instance of the given geometry using the suppled coordinate transform function. If it has
+    ''' a bounding box specified, it too will also be transformed
     ''' </summary>
     ''' <param name="xform">The coordinate transform function</param>
     ''' <returns></returns>

--- a/GeoJSON4EntityFramework/Base/TransformException.vb
+++ b/GeoJSON4EntityFramework/Base/TransformException.vb
@@ -1,0 +1,23 @@
+﻿Imports System.Runtime.Serialization
+''' <summary>
+''' Thrown when there is a failure in transforming a geometry instance
+''' </summary>
+Public Class TransformException
+    Inherits Exception
+
+    Public Sub New()
+        MyBase.New()
+    End Sub
+
+    Public Sub New(msg As String)
+        MyBase.New(msg)
+    End Sub
+
+    Public Sub New(msg As String, inner As Exception)
+        MyBase.New(msg, inner)
+    End Sub
+
+    Public Sub New(info As SerializationInfo, context As StreamingContext)
+        MyBase.New(info, context)
+    End Sub
+End Class

--- a/GeoJSON4EntityFramework/Elements/Coordinate.vb
+++ b/GeoJSON4EntityFramework/Elements/Coordinate.vb
@@ -9,6 +9,15 @@ Public Class Coordinate
         Y = _y
     End Sub
 
+    Friend Function Transform(xform As CoordinateTransform) As Coordinate
+        Dim tx As Double
+        Dim ty As Double
+        If Not xform(Me.X, Me.Y, tx, ty) Then
+            Throw New TransformException("Failed to transform coordinate")
+        End If
+        Return New Coordinate(tx, ty)
+    End Function
+
     Public ReadOnly Property Coordinate As Double()
         Get
             Return New Double() {X, Y}

--- a/GeoJSON4EntityFramework/Elements/Coordinate.vb
+++ b/GeoJSON4EntityFramework/Elements/Coordinate.vb
@@ -9,7 +9,7 @@ Public Class Coordinate
         Y = _y
     End Sub
 
-    Friend Function Transform(xform As CoordinateTransform) As Coordinate
+    Friend Function Transform(ByVal xform As CoordinateTransform) As Coordinate
         Dim tx As Double
         Dim ty As Double
         If Not xform(Me.X, Me.Y, tx, ty) Then
@@ -17,6 +17,26 @@ Public Class Coordinate
         End If
         Return New Coordinate(tx, ty)
     End Function
+
+    Friend Shared Function TransformBoundingBox(ByVal coords As Double(), ByVal xform As CoordinateTransform) As Double()
+        If coords Is Nothing Then
+            Throw New ArgumentNullException(NameOf(coords))
+        End If
+        If coords.Length <> 4 Then
+            Throw New ArgumentException("The given bounding box array does not have 4 coordinate values")
+        End If
+        Dim ll As New Coordinate(coords(1), coords(0))
+        Dim ur As New Coordinate(coords(3), coords(2))
+        Dim tll = ll.Transform(xform)
+        Dim tur = ur.Transform(xform)
+        Return New Double() {
+            tll.Y,
+            tll.X,
+            tur.Y,
+            tur.X
+        }
+    End Function
+
 
     Public ReadOnly Property Coordinate As Double()
         Get

--- a/GeoJSON4EntityFramework/Elements/CoordinateList.vb
+++ b/GeoJSON4EntityFramework/Elements/CoordinateList.vb
@@ -5,8 +5,8 @@
         MyBase.Add(New Coordinate(X, Y))
     End Sub
 
-    Friend Function CloneList(xform As CoordinateTransform) As List(Of Coordinate)
-        Dim cloned As New List(Of Coordinate)()
+    Friend Function CloneList(xform As CoordinateTransform) As CoordinateList
+        Dim cloned As New CoordinateList()
         cloned.AddRange(Me.Select(Function(coord) coord.Transform(xform)))
         Return cloned
     End Function

--- a/GeoJSON4EntityFramework/Elements/CoordinateList.vb
+++ b/GeoJSON4EntityFramework/Elements/CoordinateList.vb
@@ -4,4 +4,11 @@
     Sub AddNew(X As Double, Y As Double)
         MyBase.Add(New Coordinate(X, Y))
     End Sub
+
+    Friend Function CloneList(xform As CoordinateTransform) As List(Of Coordinate)
+        Dim cloned As New List(Of Coordinate)()
+        cloned.AddRange(Me.Select(Function(coord) coord.Transform(xform)))
+        Return cloned
+    End Function
+
 End Class

--- a/GeoJSON4EntityFramework/Elements/FeatureEF6.vb
+++ b/GeoJSON4EntityFramework/Elements/FeatureEF6.vb
@@ -4,22 +4,22 @@
         Dim f As New Feature
 
         Select Case inp.SpatialTypeName
-            Case "MultiPolygon"
+            Case GeometryType.MultiPolygon
                 f.Geometry.Add(MultiPolygon.FromDbGeometry(inp, withBoundingBox))
-            Case "Polygon"
+            Case GeometryType.Polygon
                 f.Geometry.Add(Polygon.FromDbGeometry(inp, withBoundingBox))
-            Case "Point"
+            Case GeometryType.Point
                 f.Geometry.Add(Point.FromDbGeometry(inp, withBoundingBox))
-            Case "MultiPoint"
+            Case GeometryType.MultiPoint
                 f.Geometry.Add(MultiPoint.FromDbGeometry(inp, withBoundingBox))
-            Case "LineString"
+            Case GeometryType.LineString
                 f.Geometry.Add(LineString.FromDbGeometry(inp, withBoundingBox))
-            Case "MultiLineString"
+            Case GeometryType.MultiLineString
                 f.Geometry.Add(MultiLineString.FromDbGeometry(inp, withBoundingBox))
-            Case "GeometryCollection"
+            Case GeometryType.GeometryCollection
                 f.Geometry.Add(GeometryCollection.FromDbGeometry(inp, withBoundingBox))
             Case Else
-                Throw New NotImplementedException
+                Throw New NotImplementedException(String.Format("Geometry type not handled: {0}", inp.SpatialTypeName))
         End Select
 
         Return f
@@ -31,22 +31,22 @@
         Dim inpgeom = Entity.Spatial.DbSpatialServices.Default.GeometryFromBinary(inp.AsBinary, inp.CoordinateSystemId)
 
         Select Case inpgeom.SpatialTypeName
-            Case "MultiPolygon"
+            Case GeometryType.MultiPolygon
                 f.Geometry.Add(MultiPolygon.FromDbGeometry(inpgeom, withBoundingBox))
-            Case "Polygon"
+            Case GeometryType.Polygon
                 f.Geometry.Add(Polygon.FromDbGeometry(inpgeom, withBoundingBox))
-            Case "Point"
+            Case GeometryType.Point
                 f.Geometry.Add(Point.FromDbGeometry(inpgeom, withBoundingBox))
-            Case "MultiPoint"
+            Case GeometryType.MultiPoint
                 f.Geometry.Add(MultiPoint.FromDbGeometry(inpgeom, withBoundingBox))
-            Case "LineString"
+            Case GeometryType.LineString
                 f.Geometry.Add(LineString.FromDbGeometry(inpgeom, withBoundingBox))
-            Case "MultiLineString"
+            Case GeometryType.MultiLineString
                 f.Geometry.Add(MultiLineString.FromDbGeometry(inpgeom, withBoundingBox))
-            Case "GeometryCollection"
+            Case GeometryType.GeometryCollection
                 f.Geometry.Add(GeometryCollection.FromDbGeometry(inpgeom, withBoundingBox))
             Case Else
-                Throw New NotImplementedException
+                Throw New NotImplementedException(String.Format("Geography type not handled: {0}", inp.SpatialTypeName))
         End Select
 
         Return f

--- a/GeoJSON4EntityFramework/Elements/GeometryCollection.vb
+++ b/GeoJSON4EntityFramework/Elements/GeometryCollection.vb
@@ -1,4 +1,6 @@
-﻿Partial Public Class GeometryCollection
+﻿Imports alatas.GeoJSON4EntityFramework
+
+Partial Public Class GeometryCollection
     Inherits GeoJsonGeometry(Of GeometryCollection)
     Implements IGeoJsonGeometry
 
@@ -7,4 +9,10 @@
 
     <JsonIgnore>
     Public Overrides ReadOnly Property Coordinates()
+
+    Private ReadOnly Property IGeoJsonGeometry_TypeName As String Implements IGeoJsonGeometry.TypeName
+        Get
+            Return Me.TypeName
+        End Get
+    End Property
 End Class

--- a/GeoJSON4EntityFramework/Elements/GeometryCollection.vb
+++ b/GeoJSON4EntityFramework/Elements/GeometryCollection.vb
@@ -16,6 +16,12 @@ Partial Public Class GeometryCollection
         End Get
     End Property
 
+    Private ReadOnly Property IGeoJsonGeometry_BoundingBox As Double() Implements IGeoJsonGeometry.BoundingBox
+        Get
+            Return Me.BoundingBox
+        End Get
+    End Property
+
     Public Function Transform(xform As CoordinateTransform) As IGeoJsonGeometry Implements IGeoJsonGeometry.Transform
         Dim gc As New GeometryCollection()
         If Not Me.Geometries Is Nothing Then

--- a/GeoJSON4EntityFramework/Elements/GeometryCollection.vb
+++ b/GeoJSON4EntityFramework/Elements/GeometryCollection.vb
@@ -15,4 +15,12 @@ Partial Public Class GeometryCollection
             Return Me.TypeName
         End Get
     End Property
+
+    Public Function Transform(xform As CoordinateTransform) As IGeoJsonGeometry Implements IGeoJsonGeometry.Transform
+        Dim gc As New GeometryCollection()
+        If Not Me.Geometries Is Nothing Then
+            gc.Geometries.AddRange(Me.Geometries.Select(Function(g) g.Transform(xform)))
+        End If
+        Return gc
+    End Function
 End Class

--- a/GeoJSON4EntityFramework/Elements/GeometryCollection.vb
+++ b/GeoJSON4EntityFramework/Elements/GeometryCollection.vb
@@ -27,6 +27,9 @@ Partial Public Class GeometryCollection
         If Not Me.Geometries Is Nothing Then
             gc.Geometries.AddRange(Me.Geometries.Select(Function(g) g.Transform(xform)))
         End If
+        If Not Me.BoundingBox Is Nothing Then
+            gc.BoundingBox = Coordinate.TransformBoundingBox(Me.BoundingBox, xform)
+        End If
         Return gc
     End Function
 End Class

--- a/GeoJSON4EntityFramework/Elements/GeometryCollectionEF6.vb
+++ b/GeoJSON4EntityFramework/Elements/GeometryCollectionEF6.vb
@@ -1,21 +1,25 @@
 ﻿Partial Public Class GeometryCollection
     Public Overrides Sub CreateFromDbGeometry(inp As Entity.Spatial.DbGeometry)
-        If inp.SpatialTypeName <> "GeometryCollection" Then Throw New ArgumentException
+        If inp.SpatialTypeName <> GeometryType.GeometryCollection Then Throw New ArgumentException
         Geometries.Clear()
 
         For i As Integer = 1 To inp.ElementCount
             Dim element = inp.ElementAt(i)
             Select Case element.SpatialTypeName
-                Case "MultiPolygon"
+                Case GeometryType.MultiPolygon
                     Geometries.Add(MultiPolygon.FromDbGeometry(element, WithBoundingBox))
-                Case "Polygon"
+                Case GeometryType.Polygon
                     Geometries.Add(Polygon.FromDbGeometry(element, WithBoundingBox))
-                Case "Point"
+                Case GeometryType.Point
                     Geometries.Add(Point.FromDbGeometry(element, WithBoundingBox))
-                Case "MultiPoint"
+                Case GeometryType.MultiPoint
                     Geometries.Add(MultiPoint.FromDbGeometry(element, WithBoundingBox))
+                Case GeometryType.LineString
+                    Geometries.Add(LineString.FromDbGeometry(element, WithBoundingBox))
+                Case GeometryType.MultiLineString
+                    Geometries.Add(MultiLineString.FromDbGeometry(element, WithBoundingBox))
                 Case Else
-                    Throw New NotImplementedException
+                    Throw New NotImplementedException(String.Format("Geometry type not handled: {0}", inp.SpatialTypeName))
             End Select
         Next
     End Sub

--- a/GeoJSON4EntityFramework/Elements/LineString.vb
+++ b/GeoJSON4EntityFramework/Elements/LineString.vb
@@ -47,6 +47,9 @@
         If Not Me.Points Is Nothing Then
             line.Points = Me.Points.CloneList(xform)
         End If
+        If Not Me.BoundingBox Is Nothing Then
+            line.BoundingBox = Coordinate.TransformBoundingBox(Me.BoundingBox, xform)
+        End If
         Return line
     End Function
 

--- a/GeoJSON4EntityFramework/Elements/LineString.vb
+++ b/GeoJSON4EntityFramework/Elements/LineString.vb
@@ -32,6 +32,12 @@
         End Get
     End Property
 
+    Private ReadOnly Property IGeoJsonGeometry_BoundingBox As Double() Implements IGeoJsonGeometry.BoundingBox
+        Get
+            Return Me.BoundingBox
+        End Get
+    End Property
+
     Public Function Transform(xform As CoordinateTransform) As IGeoJsonGeometry Implements IGeoJsonGeometry.Transform
         If xform Is Nothing Then
             Throw New ArgumentNullException(NameOf(xform))

--- a/GeoJSON4EntityFramework/Elements/LineString.vb
+++ b/GeoJSON4EntityFramework/Elements/LineString.vb
@@ -32,4 +32,16 @@
         End Get
     End Property
 
+    Public Function Transform(xform As CoordinateTransform) As IGeoJsonGeometry Implements IGeoJsonGeometry.Transform
+        If xform Is Nothing Then
+            Throw New ArgumentNullException(NameOf(xform))
+        End If
+
+        Dim line As New LineString()
+        If Not Me.Points Is Nothing Then
+            line.Points = Me.Points.CloneList(xform)
+        End If
+        Return line
+    End Function
+
 End Class

--- a/GeoJSON4EntityFramework/Elements/LineString.vb
+++ b/GeoJSON4EntityFramework/Elements/LineString.vb
@@ -26,4 +26,10 @@
         End Get
     End Property
 
+    Private ReadOnly Property IGeoJsonGeometry_TypeName As String Implements IGeoJsonGeometry.TypeName
+        Get
+            Return Me.TypeName
+        End Get
+    End Property
+
 End Class

--- a/GeoJSON4EntityFramework/Elements/MultiLineString.vb
+++ b/GeoJSON4EntityFramework/Elements/MultiLineString.vb
@@ -30,6 +30,9 @@ Public Class MultiLineString
         If Not Me.LineStrings Is Nothing Then
             mls.LineStrings.AddRange(Me.LineStrings.Select(Function(ls) ls.Transform(xform)))
         End If
+        If Not Me.BoundingBox Is Nothing Then
+            mls.BoundingBox = Coordinate.TransformBoundingBox(Me.BoundingBox, xform)
+        End If
         Return mls
     End Function
 End Class

--- a/GeoJSON4EntityFramework/Elements/MultiLineString.vb
+++ b/GeoJSON4EntityFramework/Elements/MultiLineString.vb
@@ -28,7 +28,7 @@ Public Class MultiLineString
     Public Function Transform(xform As CoordinateTransform) As IGeoJsonGeometry Implements IGeoJsonGeometry.Transform
         Dim mls As New MultiLineString()
         If Not Me.LineStrings Is Nothing Then
-            mls.LineStrings.AddRange(Me.LineStrings.Select(Function(ls) ls.Transform(xform)))
+            mls.LineStrings.AddRange(Me.LineStrings.Select(Function(ls) CType(ls.Transform(xform), LineString)))
         End If
         If Not Me.BoundingBox Is Nothing Then
             mls.BoundingBox = Coordinate.TransformBoundingBox(Me.BoundingBox, xform)

--- a/GeoJSON4EntityFramework/Elements/MultiLineString.vb
+++ b/GeoJSON4EntityFramework/Elements/MultiLineString.vb
@@ -10,4 +10,10 @@
             Return (From ls In LineStrings Let c = ls.Coordinates Select c).ToArray
         End Get
     End Property
+
+    Private ReadOnly Property IGeoJsonGeometry_TypeName As String Implements IGeoJsonGeometry.TypeName
+        Get
+            Return Me.TypeName
+        End Get
+    End Property
 End Class

--- a/GeoJSON4EntityFramework/Elements/MultiLineString.vb
+++ b/GeoJSON4EntityFramework/Elements/MultiLineString.vb
@@ -19,6 +19,12 @@ Public Class MultiLineString
         End Get
     End Property
 
+    Private ReadOnly Property IGeoJsonGeometry_BoundingBox As Double() Implements IGeoJsonGeometry.BoundingBox
+        Get
+            Return Me.BoundingBox
+        End Get
+    End Property
+
     Public Function Transform(xform As CoordinateTransform) As IGeoJsonGeometry Implements IGeoJsonGeometry.Transform
         Dim mls As New MultiLineString()
         If Not Me.LineStrings Is Nothing Then

--- a/GeoJSON4EntityFramework/Elements/MultiLineString.vb
+++ b/GeoJSON4EntityFramework/Elements/MultiLineString.vb
@@ -1,4 +1,6 @@
-﻿Public Class MultiLineString
+﻿Imports alatas.GeoJSON4EntityFramework
+
+Public Class MultiLineString
     Inherits GeoJsonGeometry(Of MultiLineString)
     Implements IGeoJsonGeometry
 
@@ -16,4 +18,12 @@
             Return Me.TypeName
         End Get
     End Property
+
+    Public Function Transform(xform As CoordinateTransform) As IGeoJsonGeometry Implements IGeoJsonGeometry.Transform
+        Dim mls As New MultiLineString()
+        If Not Me.LineStrings Is Nothing Then
+            mls.LineStrings.AddRange(Me.LineStrings.Select(Function(ls) ls.Transform(xform)))
+        End If
+        Return mls
+    End Function
 End Class

--- a/GeoJSON4EntityFramework/Elements/MultiPoint.vb
+++ b/GeoJSON4EntityFramework/Elements/MultiPoint.vb
@@ -1,4 +1,6 @@
-﻿Public Class MultiPoint
+﻿Imports alatas.GeoJSON4EntityFramework
+
+Public Class MultiPoint
     Inherits GeoJsonGeometry(Of MultiPoint)
     Implements IGeoJsonGeometry
 
@@ -25,4 +27,12 @@
             Return Me.TypeName
         End Get
     End Property
+
+    Public Function Transform(xform As CoordinateTransform) As IGeoJsonGeometry Implements IGeoJsonGeometry.Transform
+        Dim mpt As New MultiPoint()
+        If Not Me.Points Is Nothing Then
+            mpt.Points.AddRange(Me.Points.Select(Function(pt) pt.Transform(xform)))
+        End If
+        Return mpt
+    End Function
 End Class

--- a/GeoJSON4EntityFramework/Elements/MultiPoint.vb
+++ b/GeoJSON4EntityFramework/Elements/MultiPoint.vb
@@ -37,7 +37,7 @@ Public Class MultiPoint
     Public Function Transform(xform As CoordinateTransform) As IGeoJsonGeometry Implements IGeoJsonGeometry.Transform
         Dim mpt As New MultiPoint()
         If Not Me.Points Is Nothing Then
-            mpt.Points.AddRange(Me.Points.Select(Function(pt) pt.Transform(xform)))
+            mpt.Points.AddRange(Me.Points.Select(Function(pt) CType(pt.Transform(xform), Point)))
         End If
         If Not Me.BoundingBox Is Nothing Then
             mpt.BoundingBox = Coordinate.TransformBoundingBox(Me.BoundingBox, xform)

--- a/GeoJSON4EntityFramework/Elements/MultiPoint.vb
+++ b/GeoJSON4EntityFramework/Elements/MultiPoint.vb
@@ -28,6 +28,12 @@ Public Class MultiPoint
         End Get
     End Property
 
+    Private ReadOnly Property IGeoJsonGeometry_BoundingBox As Double() Implements IGeoJsonGeometry.BoundingBox
+        Get
+            Return Me.BoundingBox
+        End Get
+    End Property
+
     Public Function Transform(xform As CoordinateTransform) As IGeoJsonGeometry Implements IGeoJsonGeometry.Transform
         Dim mpt As New MultiPoint()
         If Not Me.Points Is Nothing Then

--- a/GeoJSON4EntityFramework/Elements/MultiPoint.vb
+++ b/GeoJSON4EntityFramework/Elements/MultiPoint.vb
@@ -39,6 +39,9 @@ Public Class MultiPoint
         If Not Me.Points Is Nothing Then
             mpt.Points.AddRange(Me.Points.Select(Function(pt) pt.Transform(xform)))
         End If
+        If Not Me.BoundingBox Is Nothing Then
+            mpt.BoundingBox = Coordinate.TransformBoundingBox(Me.BoundingBox, xform)
+        End If
         Return mpt
     End Function
 End Class

--- a/GeoJSON4EntityFramework/Elements/MultiPoint.vb
+++ b/GeoJSON4EntityFramework/Elements/MultiPoint.vb
@@ -19,4 +19,10 @@
             End If
         End Get
     End Property
+
+    Private ReadOnly Property IGeoJsonGeometry_TypeName As String Implements IGeoJsonGeometry.TypeName
+        Get
+            Return Me.TypeName
+        End Get
+    End Property
 End Class

--- a/GeoJSON4EntityFramework/Elements/MultiPolygon.vb
+++ b/GeoJSON4EntityFramework/Elements/MultiPolygon.vb
@@ -32,7 +32,7 @@ Public Class MultiPolygon
     Public Function Transform(xform As CoordinateTransform) As IGeoJsonGeometry Implements IGeoJsonGeometry.Transform
         Dim mpl As New MultiPolygon()
         If Not Me.Polygons Is Nothing Then
-            mpl.Polygons.AddRange(Me.Polygons.Select(Function(poly) poly.Transform(xform)))
+            mpl.Polygons.AddRange(Me.Polygons.Select(Function(poly) CType(poly.Transform(xform), Polygon)))
         End If
         If Not Me.BoundingBox Is Nothing Then
             mpl.BoundingBox = Coordinate.TransformBoundingBox(Me.BoundingBox, xform)

--- a/GeoJSON4EntityFramework/Elements/MultiPolygon.vb
+++ b/GeoJSON4EntityFramework/Elements/MultiPolygon.vb
@@ -14,4 +14,10 @@
             Return result
         End Get
     End Property
+
+    Private ReadOnly Property IGeoJsonGeometry_TypeName As String Implements IGeoJsonGeometry.TypeName
+        Get
+            Return Me.TypeName
+        End Get
+    End Property
 End Class

--- a/GeoJSON4EntityFramework/Elements/MultiPolygon.vb
+++ b/GeoJSON4EntityFramework/Elements/MultiPolygon.vb
@@ -1,4 +1,6 @@
-﻿Public Class MultiPolygon
+﻿Imports alatas.GeoJSON4EntityFramework
+
+Public Class MultiPolygon
     Inherits GeoJsonGeometry(Of MultiPolygon)
     Implements IGeoJsonGeometry
 
@@ -20,4 +22,12 @@
             Return Me.TypeName
         End Get
     End Property
+
+    Public Function Transform(xform As CoordinateTransform) As IGeoJsonGeometry Implements IGeoJsonGeometry.Transform
+        Dim mpl As New MultiPolygon()
+        If Not Me.Polygons Is Nothing Then
+            mpl.Polygons.AddRange(Me.Polygons.Select(Function(poly) poly.Transform(xform)))
+        End If
+        Return mpl
+    End Function
 End Class

--- a/GeoJSON4EntityFramework/Elements/MultiPolygon.vb
+++ b/GeoJSON4EntityFramework/Elements/MultiPolygon.vb
@@ -23,6 +23,12 @@ Public Class MultiPolygon
         End Get
     End Property
 
+    Private ReadOnly Property IGeoJsonGeometry_BoundingBox As Double() Implements IGeoJsonGeometry.BoundingBox
+        Get
+            Return Me.BoundingBox
+        End Get
+    End Property
+
     Public Function Transform(xform As CoordinateTransform) As IGeoJsonGeometry Implements IGeoJsonGeometry.Transform
         Dim mpl As New MultiPolygon()
         If Not Me.Polygons Is Nothing Then

--- a/GeoJSON4EntityFramework/Elements/MultiPolygon.vb
+++ b/GeoJSON4EntityFramework/Elements/MultiPolygon.vb
@@ -34,6 +34,9 @@ Public Class MultiPolygon
         If Not Me.Polygons Is Nothing Then
             mpl.Polygons.AddRange(Me.Polygons.Select(Function(poly) poly.Transform(xform)))
         End If
+        If Not Me.BoundingBox Is Nothing Then
+            mpl.BoundingBox = Coordinate.TransformBoundingBox(Me.BoundingBox, xform)
+        End If
         Return mpl
     End Function
 End Class

--- a/GeoJSON4EntityFramework/Elements/MultiPolygonEF6.vb
+++ b/GeoJSON4EntityFramework/Elements/MultiPolygonEF6.vb
@@ -1,11 +1,11 @@
 ﻿Partial Class MultiPolygon
     Public Overrides Sub CreateFromDbGeometry(inp As Entity.Spatial.DbGeometry)
-        If inp.SpatialTypeName <> "MultiPolygon" Then Throw New ArgumentException
+        If inp.SpatialTypeName <> GeometryType.MultiPolygon Then Throw New ArgumentException
         Polygons.Clear()
 
         For i As Integer = 1 To inp.ElementCount
             Dim element = inp.ElementAt(i)
-            If element.SpatialTypeName <> "Polygon" Then Throw New ArgumentException
+            If element.SpatialTypeName <> GeometryType.Polygon Then Throw New ArgumentException
             Polygons.Add(Polygon.FromDbGeometry(element))
         Next
     End Sub

--- a/GeoJSON4EntityFramework/Elements/Point.vb
+++ b/GeoJSON4EntityFramework/Elements/Point.vb
@@ -1,4 +1,6 @@
-﻿Public Class Point
+﻿Imports alatas.GeoJSON4EntityFramework
+
+Public Class Point
     Inherits GeoJsonGeometry(Of Point)
     Implements IGeoJsonGeometry
 
@@ -15,4 +17,15 @@
             Return Me.TypeName
         End Get
     End Property
+
+    Public Function Transform(xform As CoordinateTransform) As IGeoJsonGeometry Implements IGeoJsonGeometry.Transform
+        If xform Is Nothing Then
+            Throw New ArgumentNullException(NameOf(xform))
+        End If
+        Dim pt = New Point()
+        If Not Me.Point Is Nothing Then
+            pt.Point = Me.Point.Transform(xform)
+        End If
+        Return pt
+    End Function
 End Class

--- a/GeoJSON4EntityFramework/Elements/Point.vb
+++ b/GeoJSON4EntityFramework/Elements/Point.vb
@@ -9,4 +9,10 @@
             Return Point.Coordinate
         End Get
     End Property
+
+    Private ReadOnly Property IGeoJsonGeometry_TypeName As String Implements IGeoJsonGeometry.TypeName
+        Get
+            Return Me.TypeName
+        End Get
+    End Property
 End Class

--- a/GeoJSON4EntityFramework/Elements/Point.vb
+++ b/GeoJSON4EntityFramework/Elements/Point.vb
@@ -18,6 +18,12 @@ Public Class Point
         End Get
     End Property
 
+    Private ReadOnly Property IGeoJsonGeometry_BoundingBox As Double() Implements IGeoJsonGeometry.BoundingBox
+        Get
+            Return Me.BoundingBox
+        End Get
+    End Property
+
     Public Function Transform(xform As CoordinateTransform) As IGeoJsonGeometry Implements IGeoJsonGeometry.Transform
         If xform Is Nothing Then
             Throw New ArgumentNullException(NameOf(xform))

--- a/GeoJSON4EntityFramework/Elements/Point.vb
+++ b/GeoJSON4EntityFramework/Elements/Point.vb
@@ -4,6 +4,7 @@ Public Class Point
     Inherits GeoJsonGeometry(Of Point)
     Implements IGeoJsonGeometry
 
+    <JsonIgnore()>
     Public Property Point As New Coordinate(0, 0)
 
     Public Overrides ReadOnly Property Coordinates As Object

--- a/GeoJSON4EntityFramework/Elements/Point.vb
+++ b/GeoJSON4EntityFramework/Elements/Point.vb
@@ -32,6 +32,9 @@ Public Class Point
         If Not Me.Point Is Nothing Then
             pt.Point = Me.Point.Transform(xform)
         End If
+        If Not Me.BoundingBox Is Nothing Then
+            pt.BoundingBox = Coordinate.TransformBoundingBox(Me.BoundingBox, xform)
+        End If
         Return pt
     End Function
 End Class

--- a/GeoJSON4EntityFramework/Elements/Polygon.vb
+++ b/GeoJSON4EntityFramework/Elements/Polygon.vb
@@ -16,4 +16,18 @@
             Return Me.TypeName
         End Get
     End Property
+
+    Public Function Transform(xform As CoordinateTransform) As IGeoJsonGeometry Implements IGeoJsonGeometry.Transform
+        If xform Is Nothing Then
+            Throw New ArgumentNullException(NameOf(xform))
+        End If
+
+        Dim poly As New Polygon()
+
+        If Not Me.Rings Is Nothing Then
+            poly.Rings.AddRange(Me.Rings.Select(Function(ring) ring.CloneList(xform)))
+        End If
+
+        Return poly
+    End Function
 End Class

--- a/GeoJSON4EntityFramework/Elements/Polygon.vb
+++ b/GeoJSON4EntityFramework/Elements/Polygon.vb
@@ -10,4 +10,10 @@
             Return Rings
         End Get
     End Property
+
+    Private ReadOnly Property IGeoJsonGeometry_TypeName As String Implements IGeoJsonGeometry.TypeName
+        Get
+            Return Me.TypeName
+        End Get
+    End Property
 End Class

--- a/GeoJSON4EntityFramework/Elements/Polygon.vb
+++ b/GeoJSON4EntityFramework/Elements/Polygon.vb
@@ -33,6 +33,9 @@
         If Not Me.Rings Is Nothing Then
             poly.Rings.AddRange(Me.Rings.Select(Function(ring) ring.CloneList(xform)))
         End If
+        If Not Me.BoundingBox Is Nothing Then
+            poly.BoundingBox = Coordinate.TransformBoundingBox(Me.BoundingBox, xform)
+        End If
 
         Return poly
     End Function

--- a/GeoJSON4EntityFramework/Elements/Polygon.vb
+++ b/GeoJSON4EntityFramework/Elements/Polygon.vb
@@ -17,6 +17,12 @@
         End Get
     End Property
 
+    Private ReadOnly Property IGeoJsonGeometry_BoundingBox As Double() Implements IGeoJsonGeometry.BoundingBox
+        Get
+            Return Me.BoundingBox
+        End Get
+    End Property
+
     Public Function Transform(xform As CoordinateTransform) As IGeoJsonGeometry Implements IGeoJsonGeometry.Transform
         If xform Is Nothing Then
             Throw New ArgumentNullException(NameOf(xform))

--- a/GeoJSON4EntityFramework/GeoJSON4EntityFramework.vbproj
+++ b/GeoJSON4EntityFramework/GeoJSON4EntityFramework.vbproj
@@ -80,6 +80,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Base\GeoJsonGeometryEF6.vb" />
+    <Compile Include="Base\GeometryType.vb" />
     <Compile Include="Elements\FeatureEF6.vb" />
     <Compile Include="Elements\LineString.vb" />
     <Compile Include="Elements\LineStringEF6.vb" />

--- a/GeoJSON4EntityFramework/GeoJSON4EntityFramework.vbproj
+++ b/GeoJSON4EntityFramework/GeoJSON4EntityFramework.vbproj
@@ -81,6 +81,7 @@
   <ItemGroup>
     <Compile Include="Base\GeoJsonGeometryEF6.vb" />
     <Compile Include="Base\GeometryType.vb" />
+    <Compile Include="Base\TransformException.vb" />
     <Compile Include="Elements\FeatureEF6.vb" />
     <Compile Include="Elements\LineString.vb" />
     <Compile Include="Elements\LineStringEF6.vb" />

--- a/GeoJSON4EntityFramework5/Elements/FeatureEF5.vb
+++ b/GeoJSON4EntityFramework5/Elements/FeatureEF5.vb
@@ -4,22 +4,22 @@
         Dim f As New Feature
 
         Select Case inp.SpatialTypeName
-            Case "MultiPolygon"
+            Case GeometryType.MultiPolygon
                 f.Geometry.Add(MultiPolygon.FromDbGeometry(inp, withBoundingBox))
-            Case "Polygon"
+            Case GeometryType.Polygon
                 f.Geometry.Add(Polygon.FromDbGeometry(inp, withBoundingBox))
-            Case "Point"
+            Case GeometryType.Point
                 f.Geometry.Add(Point.FromDbGeometry(inp, withBoundingBox))
-            Case "MultiPoint"
+            Case GeometryType.MultiPoint
                 f.Geometry.Add(MultiPoint.FromDbGeometry(inp, withBoundingBox))
-            Case "LineString"
+            Case GeometryType.LineString
                 f.Geometry.Add(LineString.FromDbGeometry(inp, withBoundingBox))
-            Case "MultiLineString"
+            Case GeometryType.MultiLineString
                 f.Geometry.Add(MultiLineString.FromDbGeometry(inp, withBoundingBox))
-            Case "GeometryCollection"
+            Case GeometryType.GeometryCollection
                 f.Geometry.Add(GeometryCollection.FromDbGeometry(inp, withBoundingBox))
             Case Else
-                Throw New NotImplementedException
+                Throw New NotImplementedException(String.Format("Geometry type not handled: {0}", inp.SpatialTypeName))
         End Select
 
         Return f
@@ -31,22 +31,22 @@
         Dim inpgeom = Spatial.DbSpatialServices.Default.GeometryFromBinary(inp.AsBinary, inp.CoordinateSystemId)
 
         Select Case inpgeom.SpatialTypeName
-            Case "MultiPolygon"
+            Case GeometryType.MultiPolygon
                 f.Geometry.Add(MultiPolygon.FromDbGeometry(inpgeom, withBoundingBox))
-            Case "Polygon"
+            Case GeometryType.Polygon
                 f.Geometry.Add(Polygon.FromDbGeometry(inpgeom, withBoundingBox))
-            Case "Point"
+            Case GeometryType.Point
                 f.Geometry.Add(Point.FromDbGeometry(inpgeom, withBoundingBox))
-            Case "MultiPoint"
+            Case GeometryType.MultiPoint
                 f.Geometry.Add(MultiPoint.FromDbGeometry(inpgeom, withBoundingBox))
-            Case "LineString"
+            Case GeometryType.LineString
                 f.Geometry.Add(LineString.FromDbGeometry(inpgeom, withBoundingBox))
-            Case "MultiLineString"
+            Case GeometryType.MultiLineString
                 f.Geometry.Add(MultiLineString.FromDbGeometry(inpgeom, withBoundingBox))
-            Case "GeometryCollection"
+            Case GeometryType.GeometryCollection
                 f.Geometry.Add(GeometryCollection.FromDbGeometry(inpgeom, withBoundingBox))
             Case Else
-                Throw New NotImplementedException
+                Throw New NotImplementedException(String.Format("Geography type not handled: {0}", inp.SpatialTypeName))
         End Select
 
         Return f

--- a/GeoJSON4EntityFramework5/Elements/GeometryCollectionEF5.vb
+++ b/GeoJSON4EntityFramework5/Elements/GeometryCollectionEF5.vb
@@ -1,21 +1,25 @@
 ﻿Partial Public Class GeometryCollection
     Public Overrides Sub CreateFromDbGeometry(inp As Spatial.DbGeometry)
-        If inp.SpatialTypeName <> "GeometryCollection" Then Throw New ArgumentException
+        If inp.SpatialTypeName <> GeometryType.GeometryCollection Then Throw New ArgumentException
         Geometries.Clear()
 
         For i As Integer = 1 To inp.ElementCount
             Dim element = inp.ElementAt(i)
             Select Case element.SpatialTypeName
-                Case "MultiPolygon"
+                Case GeometryType.MultiPolygon
                     Geometries.Add(MultiPolygon.FromDbGeometry(element, WithBoundingBox))
-                Case "Polygon"
+                Case GeometryType.Polygon
                     Geometries.Add(Polygon.FromDbGeometry(element, WithBoundingBox))
-                Case "Point"
+                Case GeometryType.Point
                     Geometries.Add(Point.FromDbGeometry(element, WithBoundingBox))
-                Case "MultiPoint"
+                Case GeometryType.MultiPoint
                     Geometries.Add(MultiPoint.FromDbGeometry(element, WithBoundingBox))
+                Case GeometryType.LineString
+                    Geometries.Add(LineString.FromDbGeometry(element, WithBoundingBox))
+                Case GeometryType.MultiLineString
+                    Geometries.Add(MultiLineString.FromDbGeometry(element, WithBoundingBox))
                 Case Else
-                    Throw New NotImplementedException
+                    Throw New NotImplementedException(String.Format("Geometry type not handled: {0}", inp.SpatialTypeName))
             End Select
         Next
     End Sub

--- a/GeoJSON4EntityFramework5/GeoJSON4EntityFramework5.vbproj
+++ b/GeoJSON4EntityFramework5/GeoJSON4EntityFramework5.vbproj
@@ -75,6 +75,9 @@
     <Compile Include="..\GeoJSON4EntityFramework\Base\GeoJsonGeometry.vb">
       <Link>Base\GeoJsonGeometry.vb</Link>
     </Compile>
+    <Compile Include="..\GeoJSON4EntityFramework\Base\GeometryType.vb">
+      <Link>Base\GeometryType.vb</Link>
+    </Compile>
     <Compile Include="..\GeoJSON4EntityFramework\Base\IGeometry.vb">
       <Link>Base\IGeometry.vb</Link>
     </Compile>

--- a/GeoJSON4EntityFramework5/GeoJSON4EntityFramework5.vbproj
+++ b/GeoJSON4EntityFramework5/GeoJSON4EntityFramework5.vbproj
@@ -81,6 +81,9 @@
     <Compile Include="..\GeoJSON4EntityFramework\Base\IGeometry.vb">
       <Link>Base\IGeometry.vb</Link>
     </Compile>
+    <Compile Include="..\GeoJSON4EntityFramework\Base\TransformException.vb">
+      <Link>Base\TransformException.vb</Link>
+    </Compile>
     <Compile Include="..\GeoJSON4EntityFramework\Elements\Coordinate.vb">
       <Link>Elements\Coordinate.vb</Link>
     </Compile>

--- a/TestProject/Tests.vb
+++ b/TestProject/Tests.vb
@@ -33,13 +33,25 @@ Public Class Tests
     End Sub
 
     Public Sub TestSpecificType(elementType As String)
-        Dim json = GeoJsonSerializer.Serialize(Of FeatureCollection)(GetFeatureCollection(elementType.ToUpperInvariant), True)
+        Dim fc = GetFeatureCollection(elementType.ToUpperInvariant)
+        For Each f In fc.Features
+            For Each g In f.Geometry
+                Assert.AreEqual(elementType.ToUpperInvariant(), g.TypeName.ToUpperInvariant())
+            Next
+        Next
+        Dim json = GeoJsonSerializer.Serialize(Of FeatureCollection)(fc, True)
         Assert.IsNotNull(json)
         WriteOutput(json)
     End Sub
 
     Public Sub TestSpecificTypeOnline(elementType As String)
-        Dim json = GeoJsonSerializer.Serialize(Of FeatureCollection)(GetFeatureCollection(elementType.ToUpperInvariant), False)
+        Dim fc = GetFeatureCollection(elementType.ToUpperInvariant)
+        For Each f In fc.Features
+            For Each g In f.Geometry
+                Assert.AreEqual(elementType.ToUpperInvariant(), g.TypeName.ToUpperInvariant())
+            Next
+        Next
+        Dim json = GeoJsonSerializer.Serialize(Of FeatureCollection)(fc, False)
         Assert.IsNotNull(json)
         WriteOutput(json)
         SendOutput(json)

--- a/TestProject/Tests.vb
+++ b/TestProject/Tests.vb
@@ -1,4 +1,5 @@
-﻿Imports alatas.GeoJSON4EntityFramework
+﻿Imports System.Data.Entity.Spatial
+Imports alatas.GeoJSON4EntityFramework
 
 <TestClass()>
 Public Class Tests
@@ -57,59 +58,263 @@ Public Class Tests
         SendOutput(json)
     End Sub
     <TestMethod> Sub TestMultiPolygon()
-        TestSpecificType("MultiPolygon")
+        TestSpecificType(GeometryType.MultiPolygon)
     End Sub
 
     <TestMethod> Sub TestPolygon()
-        TestSpecificType("Polygon")
+        TestSpecificType(GeometryType.Polygon)
     End Sub
 
     <TestMethod> Sub TestPoint()
-        TestSpecificType("Point")
+        TestSpecificType(GeometryType.Point)
     End Sub
 
     <TestMethod> Sub TestMultiPoint()
-        TestSpecificType("MultiPoint")
+        TestSpecificType(GeometryType.MultiPoint)
     End Sub
 
     <TestMethod> Sub TestLineString()
-        TestSpecificType("LineString")
+        TestSpecificType(GeometryType.LineString)
     End Sub
 
     <TestMethod> Sub TestMultiLineString()
-        TestSpecificType("MultiLineString")
+        TestSpecificType(GeometryType.MultiLineString)
     End Sub
 
     <TestMethod> Sub TestGeometryCollection()
-        TestSpecificType("GeometryCollection")
+        TestSpecificType(GeometryType.GeometryCollection)
+    End Sub
+
+    <TestMethod> Sub TestGeometryCollectionFromDbGeometry()
+        Dim wkt = "GEOMETRYCOLLECTION(POINT (30 10), LINESTRING (30 10, 10 30, 40 40), " &
+                  "POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10)), MULTIPOINT ((10 40), (40 30), (20 20), (30 10)), " &
+                  "MULTILINESTRING ((10 10, 20 20, 10 40), (40 40, 30 30, 40 20, 30 10)), " &
+                  "MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)), ((15 5, 40 10, 10 20, 5 10, 15 5))))"
+
+        Dim geom = DbGeometry.FromText(wkt, 4326)
+        Dim gc As GeometryCollection = GeometryCollection.FromDbGeometry(geom)
+        Assert.AreEqual(6, gc.Geometries.Count)
+        Assert.AreEqual(1, gc.Geometries.Where(Function(g) g.TypeName = GeometryType.Point).Count())
+        Assert.AreEqual(1, gc.Geometries.Where(Function(g) g.TypeName = GeometryType.MultiPoint).Count())
+        Assert.AreEqual(1, gc.Geometries.Where(Function(g) g.TypeName = GeometryType.LineString).Count())
+        Assert.AreEqual(1, gc.Geometries.Where(Function(g) g.TypeName = GeometryType.MultiLineString).Count())
+        Assert.AreEqual(1, gc.Geometries.Where(Function(g) g.TypeName = GeometryType.Polygon).Count())
+        Assert.AreEqual(1, gc.Geometries.Where(Function(g) g.TypeName = GeometryType.MultiPolygon).Count())
+    End Sub
+
+    ''' <summary>
+    ''' A simple transformation function that displaces all coordinate values by +1
+    ''' </summary>
+    ''' <param name="x"></param>
+    ''' <param name="y"></param>
+    ''' <param name="tx"></param>
+    ''' <param name="ty"></param>
+    ''' <returns></returns>
+    Function CoordDisplacer(ByVal x As Double, y As Double, ByRef tx As Double, ByRef ty As Double) As Boolean
+        tx = Math.Floor(x + 1)
+        ty = Math.Floor(y + 1)
+        Return True
+    End Function
+
+    <TestMethod> Sub TestPointGeometryTransform()
+        Dim geom = DbGeometry.FromText("POINT (1 1)", 4326)
+        Dim pt As IGeoJsonGeometry = Point.FromDbGeometry(geom)
+        Dim tx_pt = pt.Transform(AddressOf CoordDisplacer)
+        Dim tx_pt2 As Point = CType(tx_pt, Point)
+        Assert.AreEqual(Of Int32)(2, tx_pt2.Point.X)
+        Assert.AreEqual(Of Int32)(2, tx_pt2.Point.Y)
+    End Sub
+
+    <TestMethod> Sub TestMultiPointGeometryTransform()
+        Dim geom = DbGeometry.FromText("MULTIPOINT ((1 1), (2 2))", 4326)
+        Dim mpt As IGeoJsonGeometry = MultiPoint.FromDbGeometry(geom)
+        Dim tx_mpt = mpt.Transform(AddressOf CoordDisplacer)
+        Dim tx_mpt2 As MultiPoint = CType(tx_mpt, MultiPoint)
+        Assert.AreEqual(Of Int32)(2, tx_mpt2.Points(0).Point.X)
+        Assert.AreEqual(Of Int32)(2, tx_mpt2.Points(0).Point.Y)
+        Assert.AreEqual(Of Int32)(3, tx_mpt2.Points(1).Point.X)
+        Assert.AreEqual(Of Int32)(3, tx_mpt2.Points(1).Point.Y)
+    End Sub
+
+    <TestMethod> Sub TestLineStringGeometryTransform()
+        Dim geom = DbGeometry.FromText("LINESTRING (1 1, 2 2)", 4326)
+        Dim ls As IGeoJsonGeometry = LineString.FromDbGeometry(geom)
+        Dim tx_ls = ls.Transform(AddressOf CoordDisplacer)
+        Dim tx_ls2 As LineString = CType(tx_ls, LineString)
+        Assert.AreEqual(Of Int32)(2, tx_ls2.Points(0).X)
+        Assert.AreEqual(Of Int32)(2, tx_ls2.Points(0).Y)
+        Assert.AreEqual(Of Int32)(3, tx_ls2.Points(1).X)
+        Assert.AreEqual(Of Int32)(3, tx_ls2.Points(1).Y)
+    End Sub
+
+    <TestMethod> Sub TestMultiLineStringGeometryTransform()
+        Dim geom = DbGeometry.FromText("MULTILINESTRING ((1 1, 2 2), (3 3, 4 4))", 4326)
+        Dim mls As IGeoJsonGeometry = MultiLineString.FromDbGeometry(geom)
+        Dim tx_mls = mls.Transform(AddressOf CoordDisplacer)
+        Dim tx_mls2 As MultiLineString = CType(tx_mls, MultiLineString)
+        Assert.AreEqual(Of Int32)(2, tx_mls2.LineStrings(0).Points(0).X)
+        Assert.AreEqual(Of Int32)(2, tx_mls2.LineStrings(0).Points(0).Y)
+        Assert.AreEqual(Of Int32)(3, tx_mls2.LineStrings(0).Points(1).X)
+        Assert.AreEqual(Of Int32)(3, tx_mls2.LineStrings(0).Points(1).Y)
+        Assert.AreEqual(Of Int32)(4, tx_mls2.LineStrings(1).Points(0).X)
+        Assert.AreEqual(Of Int32)(4, tx_mls2.LineStrings(1).Points(0).Y)
+        Assert.AreEqual(Of Int32)(5, tx_mls2.LineStrings(1).Points(1).X)
+        Assert.AreEqual(Of Int32)(5, tx_mls2.LineStrings(1).Points(1).Y)
+    End Sub
+
+    <TestMethod> Sub TestPolygonGeometryTransform()
+        Dim geom = DbGeometry.FromText("POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))", 4326)
+        Dim ply As IGeoJsonGeometry = Polygon.FromDbGeometry(geom)
+        Dim tx_ply = ply.Transform(AddressOf CoordDisplacer)
+        Dim tx_ply2 As Polygon = CType(tx_ply, Polygon)
+        Assert.AreEqual(Of Int32)(31, tx_ply2.Rings(0)(0).X)
+        Assert.AreEqual(Of Int32)(11, tx_ply2.Rings(0)(0).Y)
+        Assert.AreEqual(Of Int32)(41, tx_ply2.Rings(0)(1).X)
+        Assert.AreEqual(Of Int32)(41, tx_ply2.Rings(0)(1).Y)
+        Assert.AreEqual(Of Int32)(21, tx_ply2.Rings(0)(2).X)
+        Assert.AreEqual(Of Int32)(41, tx_ply2.Rings(0)(2).Y)
+        Assert.AreEqual(Of Int32)(11, tx_ply2.Rings(0)(3).X)
+        Assert.AreEqual(Of Int32)(21, tx_ply2.Rings(0)(3).Y)
+        Assert.AreEqual(Of Int32)(31, tx_ply2.Rings(0)(4).X)
+        Assert.AreEqual(Of Int32)(11, tx_ply2.Rings(0)(4).Y)
+    End Sub
+
+    <TestMethod> Sub TestMultiPolygonGeometryTransform()
+        Dim geom = DbGeometry.FromText("MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)), ((15 5, 40 10, 10 20, 5 10, 15 5)))", 4326)
+        Dim ply As IGeoJsonGeometry = MultiPolygon.FromDbGeometry(geom)
+        Dim tx_ply = ply.Transform(AddressOf CoordDisplacer)
+        Dim tx_ply2 As MultiPolygon = CType(tx_ply, MultiPolygon)
+        Assert.AreEqual(Of Int32)(31, tx_ply2.Polygons(0).Rings(0)(0).X)
+        Assert.AreEqual(Of Int32)(21, tx_ply2.Polygons(0).Rings(0)(0).Y)
+        Assert.AreEqual(Of Int32)(46, tx_ply2.Polygons(0).Rings(0)(1).X)
+        Assert.AreEqual(Of Int32)(41, tx_ply2.Polygons(0).Rings(0)(1).Y)
+        Assert.AreEqual(Of Int32)(11, tx_ply2.Polygons(0).Rings(0)(2).X)
+        Assert.AreEqual(Of Int32)(41, tx_ply2.Polygons(0).Rings(0)(2).Y)
+        Assert.AreEqual(Of Int32)(31, tx_ply2.Polygons(0).Rings(0)(3).X)
+        Assert.AreEqual(Of Int32)(21, tx_ply2.Polygons(0).Rings(0)(3).Y)
+
+
+        Assert.AreEqual(Of Int32)(16, tx_ply2.Polygons(1).Rings(0)(0).X)
+        Assert.AreEqual(Of Int32)(6, tx_ply2.Polygons(1).Rings(0)(0).Y)
+        Assert.AreEqual(Of Int32)(41, tx_ply2.Polygons(1).Rings(0)(1).X)
+        Assert.AreEqual(Of Int32)(11, tx_ply2.Polygons(1).Rings(0)(1).Y)
+        Assert.AreEqual(Of Int32)(11, tx_ply2.Polygons(1).Rings(0)(2).X)
+        Assert.AreEqual(Of Int32)(21, tx_ply2.Polygons(1).Rings(0)(2).Y)
+        Assert.AreEqual(Of Int32)(6, tx_ply2.Polygons(1).Rings(0)(3).X)
+        Assert.AreEqual(Of Int32)(11, tx_ply2.Polygons(1).Rings(0)(3).Y)
+        Assert.AreEqual(Of Int32)(16, tx_ply2.Polygons(1).Rings(0)(4).X)
+        Assert.AreEqual(Of Int32)(6, tx_ply2.Polygons(1).Rings(0)(4).Y)
+    End Sub
+
+    <TestMethod> Sub TestGeometryCollectionTransform()
+        Dim wkt = "GEOMETRYCOLLECTION(POINT (30 10), LINESTRING (30 10, 10 30, 40 40), " &
+                  "POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10)), MULTIPOINT ((10 40), (40 30), (20 20), (30 10)), " &
+                  "MULTILINESTRING ((10 10, 20 20, 10 40), (40 40, 30 30, 40 20, 30 10)), " &
+                  "MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)), ((15 5, 40 10, 10 20, 5 10, 15 5))))"
+
+        Dim geom = DbGeometry.FromText(wkt, 4326)
+        Dim gc As IGeoJsonGeometry = GeometryCollection.FromDbGeometry(geom)
+        Dim tx_gc = gc.Transform(AddressOf CoordDisplacer)
+        Dim tx_gc2 As GeometryCollection = CType(tx_gc, GeometryCollection)
+
+        Dim pt = CType(tx_gc2.Geometries(0), Point)
+        Dim ls = CType(tx_gc2.Geometries(1), LineString)
+        Dim pl = CType(tx_gc2.Geometries(2), Polygon)
+        Dim mpt = CType(tx_gc2.Geometries(3), MultiPoint)
+        Dim mls = CType(tx_gc2.Geometries(4), MultiLineString)
+        Dim mpl = CType(tx_gc2.Geometries(5), MultiPolygon)
+
+        Assert.AreEqual(Of Int32)(31, pt.Point.X)
+        Assert.AreEqual(Of Int32)(11, pt.Point.Y)
+
+        Assert.AreEqual(Of Int32)(31, ls.Points(0).X)
+        Assert.AreEqual(Of Int32)(11, ls.Points(0).Y)
+        Assert.AreEqual(Of Int32)(11, ls.Points(1).X)
+        Assert.AreEqual(Of Int32)(31, ls.Points(1).Y)
+        Assert.AreEqual(Of Int32)(41, ls.Points(2).X)
+        Assert.AreEqual(Of Int32)(41, ls.Points(2).Y)
+
+        Assert.AreEqual(Of Int32)(31, pl.Rings(0)(0).X)
+        Assert.AreEqual(Of Int32)(11, pl.Rings(0)(0).Y)
+        Assert.AreEqual(Of Int32)(41, pl.Rings(0)(1).X)
+        Assert.AreEqual(Of Int32)(41, pl.Rings(0)(1).Y)
+        Assert.AreEqual(Of Int32)(21, pl.Rings(0)(2).X)
+        Assert.AreEqual(Of Int32)(41, pl.Rings(0)(2).Y)
+        Assert.AreEqual(Of Int32)(11, pl.Rings(0)(3).X)
+        Assert.AreEqual(Of Int32)(21, pl.Rings(0)(3).Y)
+        Assert.AreEqual(Of Int32)(31, pl.Rings(0)(4).X)
+        Assert.AreEqual(Of Int32)(11, pl.Rings(0)(4).Y)
+
+        Assert.AreEqual(Of Int32)(11, mpt.Points(0).Point.X)
+        Assert.AreEqual(Of Int32)(41, mpt.Points(0).Point.Y)
+        Assert.AreEqual(Of Int32)(41, mpt.Points(1).Point.X)
+        Assert.AreEqual(Of Int32)(31, mpt.Points(1).Point.Y)
+        Assert.AreEqual(Of Int32)(21, mpt.Points(2).Point.X)
+        Assert.AreEqual(Of Int32)(21, mpt.Points(2).Point.Y)
+        Assert.AreEqual(Of Int32)(31, mpt.Points(3).Point.X)
+        Assert.AreEqual(Of Int32)(11, mpt.Points(3).Point.Y)
+
+        Assert.AreEqual(Of Int32)(11, mls.LineStrings(0).Points(0).X)
+        Assert.AreEqual(Of Int32)(11, mls.LineStrings(0).Points(0).Y)
+        Assert.AreEqual(Of Int32)(21, mls.LineStrings(0).Points(1).X)
+        Assert.AreEqual(Of Int32)(21, mls.LineStrings(0).Points(1).Y)
+        Assert.AreEqual(Of Int32)(11, mls.LineStrings(0).Points(2).X)
+        Assert.AreEqual(Of Int32)(41, mls.LineStrings(0).Points(2).Y)
+        Assert.AreEqual(Of Int32)(41, mls.LineStrings(1).Points(0).X)
+        Assert.AreEqual(Of Int32)(41, mls.LineStrings(1).Points(0).Y)
+        Assert.AreEqual(Of Int32)(31, mls.LineStrings(1).Points(1).X)
+        Assert.AreEqual(Of Int32)(31, mls.LineStrings(1).Points(1).Y)
+        Assert.AreEqual(Of Int32)(41, mls.LineStrings(1).Points(2).X)
+        Assert.AreEqual(Of Int32)(21, mls.LineStrings(1).Points(2).Y)
+        Assert.AreEqual(Of Int32)(31, mls.LineStrings(1).Points(3).X)
+        Assert.AreEqual(Of Int32)(11, mls.LineStrings(1).Points(3).Y)
+
+        Assert.AreEqual(Of Int32)(31, mpl.Polygons(0).Rings(0)(0).X)
+        Assert.AreEqual(Of Int32)(21, mpl.Polygons(0).Rings(0)(0).Y)
+        Assert.AreEqual(Of Int32)(46, mpl.Polygons(0).Rings(0)(1).X)
+        Assert.AreEqual(Of Int32)(41, mpl.Polygons(0).Rings(0)(1).Y)
+        Assert.AreEqual(Of Int32)(11, mpl.Polygons(0).Rings(0)(2).X)
+        Assert.AreEqual(Of Int32)(41, mpl.Polygons(0).Rings(0)(2).Y)
+        Assert.AreEqual(Of Int32)(31, mpl.Polygons(0).Rings(0)(3).X)
+        Assert.AreEqual(Of Int32)(21, mpl.Polygons(0).Rings(0)(3).Y)
+        Assert.AreEqual(Of Int32)(16, mpl.Polygons(1).Rings(0)(0).X)
+        Assert.AreEqual(Of Int32)(6, mpl.Polygons(1).Rings(0)(0).Y)
+        Assert.AreEqual(Of Int32)(41, mpl.Polygons(1).Rings(0)(1).X)
+        Assert.AreEqual(Of Int32)(11, mpl.Polygons(1).Rings(0)(1).Y)
+        Assert.AreEqual(Of Int32)(11, mpl.Polygons(1).Rings(0)(2).X)
+        Assert.AreEqual(Of Int32)(21, mpl.Polygons(1).Rings(0)(2).Y)
+        Assert.AreEqual(Of Int32)(6, mpl.Polygons(1).Rings(0)(3).X)
+        Assert.AreEqual(Of Int32)(11, mpl.Polygons(1).Rings(0)(3).Y)
+        Assert.AreEqual(Of Int32)(16, mpl.Polygons(1).Rings(0)(4).X)
+        Assert.AreEqual(Of Int32)(6, mpl.Polygons(1).Rings(0)(4).Y)
     End Sub
 
     <TestMethod> Sub OnlineTestMultiPolygon()
-        TestSpecificTypeOnline("MultiPolygon")
+        TestSpecificTypeOnline(GeometryType.MultiPolygon)
     End Sub
 
     <TestMethod> Sub OnlineTestPolygon()
-        TestSpecificTypeOnline("Polygon")
+        TestSpecificTypeOnline(GeometryType.Polygon)
     End Sub
 
     <TestMethod> Sub OnlineTestPoint()
-        TestSpecificTypeOnline("Point")
+        TestSpecificTypeOnline(GeometryType.Point)
     End Sub
 
     <TestMethod> Sub OnlineTestMultiPoint()
-        TestSpecificTypeOnline("MultiPoint")
+        TestSpecificTypeOnline(GeometryType.MultiPoint)
     End Sub
 
     <TestMethod> Sub OnlineTestLineString()
-        TestSpecificTypeOnline("LineString")
+        TestSpecificTypeOnline(GeometryType.LineString)
     End Sub
 
     <TestMethod> Sub OnlineTestMultiLineString()
-        TestSpecificTypeOnline("MultiLineString")
+        TestSpecificTypeOnline(GeometryType.MultiLineString)
     End Sub
 
     <TestMethod> Sub OnlineTestGeometryCollection()
-        TestSpecificTypeOnline("GeometryCollection")
+        TestSpecificTypeOnline(GeometryType.GeometryCollection)
     End Sub
 
 End Class

--- a/TestProjectEF5/Tests.vb
+++ b/TestProjectEF5/Tests.vb
@@ -1,4 +1,5 @@
-﻿Imports alatas.GeoJSON4EntityFramework5
+﻿Imports System.Data.Spatial
+Imports alatas.GeoJSON4EntityFramework5
 
 <TestClass()>
 Public Class Tests
@@ -56,58 +57,262 @@ Public Class Tests
         SendOutput(json)
     End Sub
     <TestMethod> Sub EF5TestMultiPolygon()
-        TestSpecificType("MultiPolygon")
+        TestSpecificType(GeometryType.MultiPolygon)
     End Sub
 
     <TestMethod> Sub EF5TestPolygon()
-        TestSpecificType("Polygon")
+        TestSpecificType(GeometryType.Polygon)
     End Sub
 
     <TestMethod> Sub EF5TestPoint()
-        TestSpecificType("Point")
+        TestSpecificType(GeometryType.Point)
     End Sub
 
     <TestMethod> Sub EF5TestMultiPoint()
-        TestSpecificType("MultiPoint")
+        TestSpecificType(GeometryType.MultiPoint)
     End Sub
 
     <TestMethod> Sub EF5TestLineString()
-        TestSpecificType("LineString")
+        TestSpecificType(GeometryType.LineString)
     End Sub
 
     <TestMethod> Sub EF5TestMultiLineString()
-        TestSpecificType("MultiLineString")
+        TestSpecificType(GeometryType.MultiLineString)
     End Sub
 
     <TestMethod> Sub EF5TestGeometryCollection()
-        TestSpecificType("GeometryCollection")
+        TestSpecificType(GeometryType.GeometryCollection)
     End Sub
 
     <TestMethod> Sub EF5OnlineTestMultiPolygon()
-        TestSpecificTypeOnline("MultiPolygon")
+        TestSpecificTypeOnline(GeometryType.MultiPolygon)
     End Sub
 
     <TestMethod> Sub EF5OnlineTestPolygon()
-        TestSpecificTypeOnline("Polygon")
+        TestSpecificTypeOnline(GeometryType.Polygon)
     End Sub
 
     <TestMethod> Sub EF5OnlineTestPoint()
-        TestSpecificTypeOnline("Point")
+        TestSpecificTypeOnline(GeometryType.Point)
     End Sub
 
     <TestMethod> Sub EF5OnlineTestMultiPoint()
-        TestSpecificTypeOnline("MultiPoint")
+        TestSpecificTypeOnline(GeometryType.MultiPoint)
     End Sub
 
     <TestMethod> Sub EF5OnlineTestLineString()
-        TestSpecificTypeOnline("LineString")
+        TestSpecificTypeOnline(GeometryType.LineString)
     End Sub
 
     <TestMethod> Sub EF5OnlineTestMultiLineString()
-        TestSpecificTypeOnline("MultiLineString")
+        TestSpecificTypeOnline(GeometryType.MultiLineString)
     End Sub
 
     <TestMethod> Sub EF5OnlineTestGeometryCollection()
-        TestSpecificTypeOnline("GeometryCollection")
+        TestSpecificTypeOnline(GeometryType.GeometryCollection)
+    End Sub
+
+    <TestMethod> Sub EF5TestGeometryCollectionFromDbGeometry()
+        Dim wkt = "GEOMETRYCOLLECTION(POINT (30 10), LINESTRING (30 10, 10 30, 40 40), " &
+                  "POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10)), MULTIPOINT ((10 40), (40 30), (20 20), (30 10)), " &
+                  "MULTILINESTRING ((10 10, 20 20, 10 40), (40 40, 30 30, 40 20, 30 10)), " &
+                  "MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)), ((15 5, 40 10, 10 20, 5 10, 15 5))))"
+
+        Dim geom = DbGeometry.FromText(wkt, 4326)
+        Dim gc As GeometryCollection = GeometryCollection.FromDbGeometry(geom)
+        Assert.AreEqual(6, gc.Geometries.Count)
+        Assert.AreEqual(1, gc.Geometries.Where(Function(g) g.TypeName = GeometryType.Point).Count())
+        Assert.AreEqual(1, gc.Geometries.Where(Function(g) g.TypeName = GeometryType.MultiPoint).Count())
+        Assert.AreEqual(1, gc.Geometries.Where(Function(g) g.TypeName = GeometryType.LineString).Count())
+        Assert.AreEqual(1, gc.Geometries.Where(Function(g) g.TypeName = GeometryType.MultiLineString).Count())
+        Assert.AreEqual(1, gc.Geometries.Where(Function(g) g.TypeName = GeometryType.Polygon).Count())
+        Assert.AreEqual(1, gc.Geometries.Where(Function(g) g.TypeName = GeometryType.MultiPolygon).Count())
+    End Sub
+
+    ''' <summary>
+    ''' A simple transformation function that displaces all coordinate values by +1
+    ''' </summary>
+    ''' <param name="x"></param>
+    ''' <param name="y"></param>
+    ''' <param name="tx"></param>
+    ''' <param name="ty"></param>
+    ''' <returns></returns>
+    Function CoordDisplacer(ByVal x As Double, y As Double, ByRef tx As Double, ByRef ty As Double) As Boolean
+        tx = Math.Floor(x + 1)
+        ty = Math.Floor(y + 1)
+        Return True
+    End Function
+
+    <TestMethod> Sub EF5TestPointGeometryTransform()
+        Dim geom = DbGeometry.FromText("POINT (1 1)", 4326)
+        Dim pt As IGeoJsonGeometry = Point.FromDbGeometry(geom)
+        Dim tx_pt = pt.Transform(AddressOf CoordDisplacer)
+        Dim tx_pt2 As Point = CType(tx_pt, Point)
+        Assert.AreEqual(Of Int32)(2, tx_pt2.Point.X)
+        Assert.AreEqual(Of Int32)(2, tx_pt2.Point.Y)
+    End Sub
+
+    <TestMethod> Sub EF5TestMultiPointGeometryTransform()
+        Dim geom = DbGeometry.FromText("MULTIPOINT ((1 1), (2 2))", 4326)
+        Dim mpt As IGeoJsonGeometry = MultiPoint.FromDbGeometry(geom)
+        Dim tx_mpt = mpt.Transform(AddressOf CoordDisplacer)
+        Dim tx_mpt2 As MultiPoint = CType(tx_mpt, MultiPoint)
+        Assert.AreEqual(Of Int32)(2, tx_mpt2.Points(0).Point.X)
+        Assert.AreEqual(Of Int32)(2, tx_mpt2.Points(0).Point.Y)
+        Assert.AreEqual(Of Int32)(3, tx_mpt2.Points(1).Point.X)
+        Assert.AreEqual(Of Int32)(3, tx_mpt2.Points(1).Point.Y)
+    End Sub
+
+    <TestMethod> Sub EF5TestLineStringGeometryTransform()
+        Dim geom = DbGeometry.FromText("LINESTRING (1 1, 2 2)", 4326)
+        Dim ls As IGeoJsonGeometry = LineString.FromDbGeometry(geom)
+        Dim tx_ls = ls.Transform(AddressOf CoordDisplacer)
+        Dim tx_ls2 As LineString = CType(tx_ls, LineString)
+        Assert.AreEqual(Of Int32)(2, tx_ls2.Points(0).X)
+        Assert.AreEqual(Of Int32)(2, tx_ls2.Points(0).Y)
+        Assert.AreEqual(Of Int32)(3, tx_ls2.Points(1).X)
+        Assert.AreEqual(Of Int32)(3, tx_ls2.Points(1).Y)
+    End Sub
+
+    <TestMethod> Sub EF5TestMultiLineStringGeometryTransform()
+        Dim geom = DbGeometry.FromText("MULTILINESTRING ((1 1, 2 2), (3 3, 4 4))", 4326)
+        Dim mls As IGeoJsonGeometry = MultiLineString.FromDbGeometry(geom)
+        Dim tx_mls = mls.Transform(AddressOf CoordDisplacer)
+        Dim tx_mls2 As MultiLineString = CType(tx_mls, MultiLineString)
+        Assert.AreEqual(Of Int32)(2, tx_mls2.LineStrings(0).Points(0).X)
+        Assert.AreEqual(Of Int32)(2, tx_mls2.LineStrings(0).Points(0).Y)
+        Assert.AreEqual(Of Int32)(3, tx_mls2.LineStrings(0).Points(1).X)
+        Assert.AreEqual(Of Int32)(3, tx_mls2.LineStrings(0).Points(1).Y)
+        Assert.AreEqual(Of Int32)(4, tx_mls2.LineStrings(1).Points(0).X)
+        Assert.AreEqual(Of Int32)(4, tx_mls2.LineStrings(1).Points(0).Y)
+        Assert.AreEqual(Of Int32)(5, tx_mls2.LineStrings(1).Points(1).X)
+        Assert.AreEqual(Of Int32)(5, tx_mls2.LineStrings(1).Points(1).Y)
+    End Sub
+
+    <TestMethod> Sub EF5TestPolygonGeometryTransform()
+        Dim geom = DbGeometry.FromText("POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))", 4326)
+        Dim ply As IGeoJsonGeometry = Polygon.FromDbGeometry(geom)
+        Dim tx_ply = ply.Transform(AddressOf CoordDisplacer)
+        Dim tx_ply2 As Polygon = CType(tx_ply, Polygon)
+        Assert.AreEqual(Of Int32)(31, tx_ply2.Rings(0)(0).X)
+        Assert.AreEqual(Of Int32)(11, tx_ply2.Rings(0)(0).Y)
+        Assert.AreEqual(Of Int32)(41, tx_ply2.Rings(0)(1).X)
+        Assert.AreEqual(Of Int32)(41, tx_ply2.Rings(0)(1).Y)
+        Assert.AreEqual(Of Int32)(21, tx_ply2.Rings(0)(2).X)
+        Assert.AreEqual(Of Int32)(41, tx_ply2.Rings(0)(2).Y)
+        Assert.AreEqual(Of Int32)(11, tx_ply2.Rings(0)(3).X)
+        Assert.AreEqual(Of Int32)(21, tx_ply2.Rings(0)(3).Y)
+        Assert.AreEqual(Of Int32)(31, tx_ply2.Rings(0)(4).X)
+        Assert.AreEqual(Of Int32)(11, tx_ply2.Rings(0)(4).Y)
+    End Sub
+
+    <TestMethod> Sub EF5TestMultiPolygonGeometryTransform()
+        Dim geom = DbGeometry.FromText("MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)), ((15 5, 40 10, 10 20, 5 10, 15 5)))", 4326)
+        Dim ply As IGeoJsonGeometry = MultiPolygon.FromDbGeometry(geom)
+        Dim tx_ply = ply.Transform(AddressOf CoordDisplacer)
+        Dim tx_ply2 As MultiPolygon = CType(tx_ply, MultiPolygon)
+        Assert.AreEqual(Of Int32)(31, tx_ply2.Polygons(0).Rings(0)(0).X)
+        Assert.AreEqual(Of Int32)(21, tx_ply2.Polygons(0).Rings(0)(0).Y)
+        Assert.AreEqual(Of Int32)(46, tx_ply2.Polygons(0).Rings(0)(1).X)
+        Assert.AreEqual(Of Int32)(41, tx_ply2.Polygons(0).Rings(0)(1).Y)
+        Assert.AreEqual(Of Int32)(11, tx_ply2.Polygons(0).Rings(0)(2).X)
+        Assert.AreEqual(Of Int32)(41, tx_ply2.Polygons(0).Rings(0)(2).Y)
+        Assert.AreEqual(Of Int32)(31, tx_ply2.Polygons(0).Rings(0)(3).X)
+        Assert.AreEqual(Of Int32)(21, tx_ply2.Polygons(0).Rings(0)(3).Y)
+
+
+        Assert.AreEqual(Of Int32)(16, tx_ply2.Polygons(1).Rings(0)(0).X)
+        Assert.AreEqual(Of Int32)(6, tx_ply2.Polygons(1).Rings(0)(0).Y)
+        Assert.AreEqual(Of Int32)(41, tx_ply2.Polygons(1).Rings(0)(1).X)
+        Assert.AreEqual(Of Int32)(11, tx_ply2.Polygons(1).Rings(0)(1).Y)
+        Assert.AreEqual(Of Int32)(11, tx_ply2.Polygons(1).Rings(0)(2).X)
+        Assert.AreEqual(Of Int32)(21, tx_ply2.Polygons(1).Rings(0)(2).Y)
+        Assert.AreEqual(Of Int32)(6, tx_ply2.Polygons(1).Rings(0)(3).X)
+        Assert.AreEqual(Of Int32)(11, tx_ply2.Polygons(1).Rings(0)(3).Y)
+        Assert.AreEqual(Of Int32)(16, tx_ply2.Polygons(1).Rings(0)(4).X)
+        Assert.AreEqual(Of Int32)(6, tx_ply2.Polygons(1).Rings(0)(4).Y)
+    End Sub
+
+    <TestMethod> Sub EF5TestGeometryCollectionTransform()
+        Dim wkt = "GEOMETRYCOLLECTION(POINT (30 10), LINESTRING (30 10, 10 30, 40 40), " &
+                  "POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10)), MULTIPOINT ((10 40), (40 30), (20 20), (30 10)), " &
+                  "MULTILINESTRING ((10 10, 20 20, 10 40), (40 40, 30 30, 40 20, 30 10)), " &
+                  "MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)), ((15 5, 40 10, 10 20, 5 10, 15 5))))"
+
+        Dim geom = DbGeometry.FromText(wkt, 4326)
+        Dim gc As IGeoJsonGeometry = GeometryCollection.FromDbGeometry(geom)
+        Dim tx_gc = gc.Transform(AddressOf CoordDisplacer)
+        Dim tx_gc2 As GeometryCollection = CType(tx_gc, GeometryCollection)
+
+        Dim pt = CType(tx_gc2.Geometries(0), Point)
+        Dim ls = CType(tx_gc2.Geometries(1), LineString)
+        Dim pl = CType(tx_gc2.Geometries(2), Polygon)
+        Dim mpt = CType(tx_gc2.Geometries(3), MultiPoint)
+        Dim mls = CType(tx_gc2.Geometries(4), MultiLineString)
+        Dim mpl = CType(tx_gc2.Geometries(5), MultiPolygon)
+
+        Assert.AreEqual(Of Int32)(31, pt.Point.X)
+        Assert.AreEqual(Of Int32)(11, pt.Point.Y)
+
+        Assert.AreEqual(Of Int32)(31, ls.Points(0).X)
+        Assert.AreEqual(Of Int32)(11, ls.Points(0).Y)
+        Assert.AreEqual(Of Int32)(11, ls.Points(1).X)
+        Assert.AreEqual(Of Int32)(31, ls.Points(1).Y)
+        Assert.AreEqual(Of Int32)(41, ls.Points(2).X)
+        Assert.AreEqual(Of Int32)(41, ls.Points(2).Y)
+
+        Assert.AreEqual(Of Int32)(31, pl.Rings(0)(0).X)
+        Assert.AreEqual(Of Int32)(11, pl.Rings(0)(0).Y)
+        Assert.AreEqual(Of Int32)(41, pl.Rings(0)(1).X)
+        Assert.AreEqual(Of Int32)(41, pl.Rings(0)(1).Y)
+        Assert.AreEqual(Of Int32)(21, pl.Rings(0)(2).X)
+        Assert.AreEqual(Of Int32)(41, pl.Rings(0)(2).Y)
+        Assert.AreEqual(Of Int32)(11, pl.Rings(0)(3).X)
+        Assert.AreEqual(Of Int32)(21, pl.Rings(0)(3).Y)
+        Assert.AreEqual(Of Int32)(31, pl.Rings(0)(4).X)
+        Assert.AreEqual(Of Int32)(11, pl.Rings(0)(4).Y)
+
+        Assert.AreEqual(Of Int32)(11, mpt.Points(0).Point.X)
+        Assert.AreEqual(Of Int32)(41, mpt.Points(0).Point.Y)
+        Assert.AreEqual(Of Int32)(41, mpt.Points(1).Point.X)
+        Assert.AreEqual(Of Int32)(31, mpt.Points(1).Point.Y)
+        Assert.AreEqual(Of Int32)(21, mpt.Points(2).Point.X)
+        Assert.AreEqual(Of Int32)(21, mpt.Points(2).Point.Y)
+        Assert.AreEqual(Of Int32)(31, mpt.Points(3).Point.X)
+        Assert.AreEqual(Of Int32)(11, mpt.Points(3).Point.Y)
+
+        Assert.AreEqual(Of Int32)(11, mls.LineStrings(0).Points(0).X)
+        Assert.AreEqual(Of Int32)(11, mls.LineStrings(0).Points(0).Y)
+        Assert.AreEqual(Of Int32)(21, mls.LineStrings(0).Points(1).X)
+        Assert.AreEqual(Of Int32)(21, mls.LineStrings(0).Points(1).Y)
+        Assert.AreEqual(Of Int32)(11, mls.LineStrings(0).Points(2).X)
+        Assert.AreEqual(Of Int32)(41, mls.LineStrings(0).Points(2).Y)
+        Assert.AreEqual(Of Int32)(41, mls.LineStrings(1).Points(0).X)
+        Assert.AreEqual(Of Int32)(41, mls.LineStrings(1).Points(0).Y)
+        Assert.AreEqual(Of Int32)(31, mls.LineStrings(1).Points(1).X)
+        Assert.AreEqual(Of Int32)(31, mls.LineStrings(1).Points(1).Y)
+        Assert.AreEqual(Of Int32)(41, mls.LineStrings(1).Points(2).X)
+        Assert.AreEqual(Of Int32)(21, mls.LineStrings(1).Points(2).Y)
+        Assert.AreEqual(Of Int32)(31, mls.LineStrings(1).Points(3).X)
+        Assert.AreEqual(Of Int32)(11, mls.LineStrings(1).Points(3).Y)
+
+        Assert.AreEqual(Of Int32)(31, mpl.Polygons(0).Rings(0)(0).X)
+        Assert.AreEqual(Of Int32)(21, mpl.Polygons(0).Rings(0)(0).Y)
+        Assert.AreEqual(Of Int32)(46, mpl.Polygons(0).Rings(0)(1).X)
+        Assert.AreEqual(Of Int32)(41, mpl.Polygons(0).Rings(0)(1).Y)
+        Assert.AreEqual(Of Int32)(11, mpl.Polygons(0).Rings(0)(2).X)
+        Assert.AreEqual(Of Int32)(41, mpl.Polygons(0).Rings(0)(2).Y)
+        Assert.AreEqual(Of Int32)(31, mpl.Polygons(0).Rings(0)(3).X)
+        Assert.AreEqual(Of Int32)(21, mpl.Polygons(0).Rings(0)(3).Y)
+        Assert.AreEqual(Of Int32)(16, mpl.Polygons(1).Rings(0)(0).X)
+        Assert.AreEqual(Of Int32)(6, mpl.Polygons(1).Rings(0)(0).Y)
+        Assert.AreEqual(Of Int32)(41, mpl.Polygons(1).Rings(0)(1).X)
+        Assert.AreEqual(Of Int32)(11, mpl.Polygons(1).Rings(0)(1).Y)
+        Assert.AreEqual(Of Int32)(11, mpl.Polygons(1).Rings(0)(2).X)
+        Assert.AreEqual(Of Int32)(21, mpl.Polygons(1).Rings(0)(2).Y)
+        Assert.AreEqual(Of Int32)(6, mpl.Polygons(1).Rings(0)(3).X)
+        Assert.AreEqual(Of Int32)(11, mpl.Polygons(1).Rings(0)(3).Y)
+        Assert.AreEqual(Of Int32)(16, mpl.Polygons(1).Rings(0)(4).X)
+        Assert.AreEqual(Of Int32)(6, mpl.Polygons(1).Rings(0)(4).Y)
     End Sub
 End Class

--- a/TestProjectEF5/Tests.vb
+++ b/TestProjectEF5/Tests.vb
@@ -32,13 +32,25 @@ Public Class Tests
     End Sub
 
     Public Sub TestSpecificType(elementType As String)
-        Dim json = GeoJsonSerializer.Serialize(Of FeatureCollection)(GetFeatureCollection(elementType.ToUpperInvariant), True)
+        Dim fc = GetFeatureCollection(elementType.ToUpperInvariant)
+        For Each f In fc.Features
+            For Each g In f.Geometry
+                Assert.AreEqual(elementType.ToUpperInvariant(), g.TypeName.ToUpperInvariant())
+            Next
+        Next
+        Dim json = GeoJsonSerializer.Serialize(Of FeatureCollection)(fc, True)
         Assert.IsNotNull(json)
         WriteOutput(json)
     End Sub
 
     Public Sub TestSpecificTypeOnline(elementType As String)
-        Dim json = GeoJsonSerializer.Serialize(Of FeatureCollection)(GetFeatureCollection(elementType.ToUpperInvariant), False)
+        Dim fc = GetFeatureCollection(elementType.ToUpperInvariant)
+        For Each f In fc.Features
+            For Each g In f.Geometry
+                Assert.AreEqual(elementType.ToUpperInvariant(), g.TypeName.ToUpperInvariant())
+            Next
+        Next
+        Dim json = GeoJsonSerializer.Serialize(Of FeatureCollection)(fc, False)
         Assert.IsNotNull(json)
         WriteOutput(json)
         SendOutput(json)


### PR DESCRIPTION
This pull request enhances the IGeoJsonGeometry interface to have more utility than being just a marker interface for JSON serialization:
- Add readonly TypeName property exposing the TypeName property that all Geometry classes have, allowing for easy type identification without trial-and-error casting or CLR type checks.
- Add a Transform method that allows an IGeoJsonGeometry to be transformed (re-projected) through a user-supplied transformation function.
- Add readonly BoundingBox property exposing the BoundingBox property that all Geometry classes have.

Also included is some fixes:
- JsonIgnore the Point property of Point class
- GeometryCollection.FromDbGeometry() throws NotImplementedException if it contains component LineString or MultiLineString instances
- For any FromDbGeometry() method that throws NotImplementedException (because of unknown/unsupported geometry type), indicate this type in the exception message.

Also included is unit tests covering the transformation functionality and verifying the DbGeometry -> GeometryCollection conversion supports all valid component geometry types
